### PR TITLE
Update CocoonP2PClientHandler.as

### DIFF
--- a/library/AIRServer/src/be/aboutme/airserver/endpoints/cocoonP2P/CocoonP2PClientHandler.as
+++ b/library/AIRServer/src/be/aboutme/airserver/endpoints/cocoonP2P/CocoonP2PClientHandler.as
@@ -70,7 +70,11 @@ package be.aboutme.airserver.endpoints.cocoonP2P
 			if(messagesToHandle.length > 0)
 			{
 				message = new Message();
-				message.data = messagesToHandle.shift();
+
+				var tmp:Object = messagesToHandle.shift();
+				message.command = tmp.command;
+				message.data = tmp.data;
+				message.senderId = tmp.senderId;
 				
 				_messagesAvailable = (messagesToHandle.length > 0);
 			}


### PR DESCRIPTION
Messages sent using Cocoonp2p came back as a message in the data field of a message. This update corrects that.
